### PR TITLE
Stay on letsencrypt

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -54,6 +54,12 @@
   changed_when: upgrade_result.rc == 0 and "Upgrade success" in upgrade_result.stdout
   become_user: "{{ acme_sh_become_user }}"
 
+- name: Use letsencrypt as CA
+  command: ./acme.sh --set-default-ca --server letsencrypt
+  args:
+    chdir: "~/.acme.sh"
+  become_user: "{{ acme_sh_become_user }}"
+
 - name: Create certificate path
   file:
     path: "{{ acme_sh_copy_certs_to_path }}"


### PR DESCRIPTION
acme.sh has switched from LetsEncrypt to ZeroSSL as default CA. But documentation and possibly some options of this role expects letsencrypt.
According to my tests and https://github.com/acmesh-official/acme.sh the default is already set to ZeroSSL. But according to this it shouldn't happen until august 1st:
https://community.letsencrypt.org/t/the-acme-sh-will-change-default-ca-to-zerossl-on-august-1st-2021/144052